### PR TITLE
Added recognition models (.h5 and .onnx)

### DIFF
--- a/model/asl_alphabet.h5
+++ b/model/asl_alphabet.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:719c2a0c773f98cdaea3fdfc0e088e0b3baaef053f933b2d58a22b7331f63412
+size 149684496


### PR DESCRIPTION
Recognition models for ASL (.h5 and .onnx). ONNX file is uploaded for OpenCV 4.5 support.